### PR TITLE
feat: Add getCartItemCount query to GraphQL schema and resolver

### DIFF
--- a/src/cart-items/cart-items.resolver.ts
+++ b/src/cart-items/cart-items.resolver.ts
@@ -17,7 +17,7 @@ export class CartItemsResolver {
         return this.cartItemsService.getUserCartItems(user.id)
     }
 
-    @Query(() => CartItemEntity, { name: "getCartItem" }) // get cart-items of current user
+    @Query(() => CartItemEntity, { name: "getCartItem" })
     async getCartItem(
         @Args("id") id: string,
         @CurrentUser() user: UserEntity
@@ -54,5 +54,10 @@ export class CartItemsResolver {
     async clearCart(@CurrentUser() user: UserEntity): Promise<boolean> {
         await this.cartItemsService.removeAllUserCartItems(user.id)
         return true
+    }
+
+    @Query(() => Number, { name: "getCartItemCount" })
+    async getCartItemCount(@CurrentUser() user: UserEntity): Promise<number> {
+        return this.cartItemsService.getCartItemCount(user.id)
     }
 }

--- a/src/cart-items/cart-items.service.ts
+++ b/src/cart-items/cart-items.service.ts
@@ -16,6 +16,14 @@ export class CartItemsService {
         return user
     }
 
+    async getCartItemCount(userId: string): Promise<number> {
+        const count = await this.prisma.cartItem.count({
+            where: { userId }
+        })
+
+        return count
+    }
+
     async addDesignToCart(
         createCartItemDto: CreateCartItemDto,
         userId: string

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -404,6 +404,7 @@ type Query {
   districts(provinceId: Int!): [District!]!
   getApplicableDiscount(productId: String!, quantity: Float!): Float!
   getCartItem(id: String!): CartItemEntity!
+  getCartItemCount: Float!
   getMe: UserEntity!
   getMyFactory: FactoryEntity!
   notification(id: ID!): NotificationEntity!


### PR DESCRIPTION
- Introduced `getCartItemCount` query to retrieve the total number of cart items for the current user.
- Implemented corresponding method in CartItemsService to count cart items based on user ID.
- Updated GraphQL schema to include the new query for better cart management.