### PR TITLE
feat: add max evaluation criteria to SystemConfigOrder and related up…

### DIFF
--- a/prisma/migrations/20250531075605_add_max_evaluation_criteria/migration.sql
+++ b/prisma/migrations/20250531075605_add_max_evaluation_criteria/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "SystemConfigOrder" ADD COLUMN     "maxEvaluationCriteria" INTEGER NOT NULL DEFAULT 3;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -611,6 +611,9 @@ model SystemConfigOrder {
   voucherBaseTypeForRefund VoucherType @default(FIXED_VALUE)
   voucherBaseLimitedUsage Int @default(1)
   voucherBaseMaxDiscountValue Int @default(100000)
+
+  // Evaluation criteria
+  maxEvaluationCriteria Int @default(3)
 }
 
 model UserBank {

--- a/src/pdf/pdf.controller.ts
+++ b/src/pdf/pdf.controller.ts
@@ -1,19 +1,19 @@
-import { Controller, Get, Header, Res } from '@nestjs/common';
-import { Response } from 'express';
-import { PdfService } from './pdf.service';
+import { Controller, Get, Header, Res } from "@nestjs/common"
+import { Response } from "express"
+import { PdfService } from "./pdf.service"
 
-@Controller('pdf')
+@Controller("pdf")
 export class PdfController {
-  constructor(private readonly pdfService: PdfService) {}
+    constructor(private readonly pdfService: PdfService) {}
 
-  @Get('hello-world')
-  @Header('Content-Type', 'application/pdf')
-  @Header('Content-Disposition', 'attachment; filename=hello-world.pdf')
-  async generateHelloWorldPdf(@Res() res: Response): Promise<void> {
-    // Generate the PDF
-    const pdfBuffer = await this.pdfService.generateHelloWorldPdf();
-    
-    // Send the PDF as a response
-    res.send(pdfBuffer);
-  }
-} 
+    @Get("hello-world")
+    @Header("Content-Type", "application/pdf")
+    @Header("Content-Disposition", "attachment; filename=hello-world.pdf")
+    async generateHelloWorldPdf(@Res() res: Response): Promise<void> {
+        // Generate the PDF
+        const pdfBuffer = await this.pdfService.generateHelloWorldPdf()
+
+        // Send the PDF as a response
+        res.send(pdfBuffer)
+    }
+}

--- a/src/pdf/pdf.service.ts
+++ b/src/pdf/pdf.service.ts
@@ -1,53 +1,51 @@
-import { Injectable } from '@nestjs/common';
-import { join } from 'path';
-import PdfPrinter from 'pdfmake';
-import * as pdfMake from 'pdfmake/build/pdfmake';
-import * as pdfFonts from 'pdfmake/build/vfs_fonts';
-import { BufferOptions, TDocumentDefinitions } from 'pdfmake/interfaces';
+import { Injectable } from "@nestjs/common"
+import { join } from "path"
+import PdfPrinter from "pdfmake"
+import * as pdfMake from "pdfmake/build/pdfmake"
+import * as pdfFonts from "pdfmake/build/vfs_fonts"
+import { BufferOptions, TDocumentDefinitions } from "pdfmake/interfaces"
 
 @Injectable()
 export class PdfService {
-  constructor() {
-    // Initialize pdfmake with the virtual file system
-    (pdfMake as any).vfs = pdfFonts.vfs;
-  }
-
-  /**
-   * Generates a simple "Hello World" PDF
-   * @returns Buffer containing the PDF data
-   */
-  generateHelloWorldPdf(): PDFKit.PDFDocument {
-    // Define the document definition
-    const docDefinition: TDocumentDefinitions = {
-      content: [
-        { text: 'Hello World!', style: 'header' },
-        { text: 'This is a PDF generated with pdfmake in NestJS', margin: [0, 10, 0, 0] },
-        { text: 'Current date: ' + new Date().toLocaleDateString(), margin: [0, 10, 0, 0] },
-      ],
-      styles: {
-        header: {
-          fontSize: 22,
-          bold: true,
-          margin: [0, 0, 0, 10],
-        },
-      },
+    constructor() {
+        // Initialize pdfmake with the virtual file system
+        ;(pdfMake as any).vfs = pdfFonts.vfs
     }
 
-    const fonts = {
-        CenturyGothic: {
-            normal: join(process.cwd(), 'assets/fonts/century-gothic/GOTHIC.woff'),
-            bold: join(process.cwd(), 'assets/fonts/century-gothic/GOTHICB.woff'),
-            italics: join(process.cwd(), 'assets/fonts/century-gothic/GOTHICI.woff'),
-            bolditalics: join(process.cwd(), 'assets/fonts/century-gothic/GOTHICBI.woff'),
+    /**
+     * Generates a simple "Hello World" PDF
+     * @returns Buffer containing the PDF data
+     */
+    generateHelloWorldPdf(): PDFKit.PDFDocument {
+        // Define the document definition
+        const docDefinition: TDocumentDefinitions = {
+            content: [
+                { text: "Hello World!", style: "header" },
+                { text: "This is a PDF generated with pdfmake in NestJS", margin: [0, 10, 0, 0] },
+                { text: "Current date: " + new Date().toLocaleDateString(), margin: [0, 10, 0, 0] }
+            ],
+            styles: {
+                header: {
+                    fontSize: 22,
+                    bold: true,
+                    margin: [0, 0, 0, 10]
+                }
+            }
         }
-    }
 
-    const printer = new PdfPrinter(fonts);
+        const fonts = {
+            CenturyGothic: {
+                normal: join(process.cwd(), "assets/fonts/century-gothic/GOTHIC.woff"),
+                bold: join(process.cwd(), "assets/fonts/century-gothic/GOTHICB.woff"),
+                italics: join(process.cwd(), "assets/fonts/century-gothic/GOTHICI.woff"),
+                bolditalics: join(process.cwd(), "assets/fonts/century-gothic/GOTHICBI.woff")
+            }
+        }
 
-    const options: BufferOptions = {
-        
+        const printer = new PdfPrinter(fonts)
+
+        const options: BufferOptions = {}
+
+        return printer.createPdfKitDocument(docDefinition, options)
     }
-    
-    return printer.createPdfKitDocument(docDefinition, options);
-  }
 }

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -1225,6 +1225,7 @@ type SystemConfigOrderEntity {
   legitPointToSuspend: Int!
   limitFactoryRejectOrders: Int!
   limitReworkTimes: Int!
+  maxEvaluationCriteria: Int!
   maxLegitPoint: Int!
   maxProductionCapacity: Int!
   maxProductionTimeInMinutes: Int!
@@ -1432,6 +1433,7 @@ input UpdateSystemConfigOrderDto {
   legitPointToSuspend: Int
   limitFactoryRejectOrders: Int
   limitReworkTimes: Int
+  maxEvaluationCriteria: Int
   maxLegitPoint: Int
   maxProductionCapacity: Int
   maxProductionTimeInMinutes: Int

--- a/src/system-config-order/dto/update-system-config-order.dto.ts
+++ b/src/system-config-order/dto/update-system-config-order.dto.ts
@@ -107,4 +107,9 @@ export class UpdateSystemConfigOrderDto {
     @IsNumber()
     @Min(1)
     voucherBaseMaxDiscountValue?: number
+
+    @Field(() => Int, { nullable: true })
+    @IsNumber()
+    @Min(1)
+    maxEvaluationCriteria?: number
 }

--- a/src/system-config-order/entities/system-config-order.entity.ts
+++ b/src/system-config-order/entities/system-config-order.entity.ts
@@ -71,6 +71,9 @@ export class SystemConfigOrderEntity {
     @Field(() => Int)
     voucherBaseMaxDiscountValue: number
 
+    @Field(() => Int)
+    maxEvaluationCriteria: number
+
     constructor(partial: Partial<SystemConfigOrderEntity>) {
         Object.assign(this, partial)
     }


### PR DESCRIPTION
…dates

- Introduced a new field `maxEvaluationCriteria` in the SystemConfigOrder model with a default value of 3.
- Updated the GraphQL schema to include `maxEvaluationCriteria` in the SystemConfigOrderEntity and UpdateSystemConfigOrderDto.
- Enhanced OrdersService to validate evaluation criteria against the new maximum limit during order creation.
- Created a migration script to add the `maxEvaluationCriteria` column to the database.