### PR TITLE
feat: add CheckQualityFailedEvaluationCriteria model and integrate in…

### DIFF
--- a/prisma/migrations/20250602125226_add_failed_evaluation_criteria/migration.sql
+++ b/prisma/migrations/20250602125226_add_failed_evaluation_criteria/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "CheckQualityFailedEvaluationCriteria" (
+    "id" TEXT NOT NULL,
+    "checkQualityId" TEXT NOT NULL,
+    "evaluationCriteriaId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CheckQualityFailedEvaluationCriteria_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CheckQualityFailedEvaluationCriteria_checkQualityId_evaluat_key" ON "CheckQualityFailedEvaluationCriteria"("checkQualityId", "evaluationCriteriaId");
+
+-- AddForeignKey
+ALTER TABLE "CheckQualityFailedEvaluationCriteria" ADD CONSTRAINT "CheckQualityFailedEvaluationCriteria_checkQualityId_fkey" FOREIGN KEY ("checkQualityId") REFERENCES "CheckQuality"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CheckQualityFailedEvaluationCriteria" ADD CONSTRAINT "CheckQualityFailedEvaluationCriteria_evaluationCriteriaId_fkey" FOREIGN KEY ("evaluationCriteriaId") REFERENCES "EvaluationCriteria"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -577,6 +577,19 @@ model CheckQuality {
 
   task        Task        @relation(fields: [taskId], references: [id])
   orderDetail OrderDetail @relation(fields: [orderDetailId], references: [id])
+  failedEvaluationCriteria CheckQualityFailedEvaluationCriteria[]
+}
+
+model CheckQualityFailedEvaluationCriteria {
+  id                    String   @id @default(uuid())
+  checkQualityId       String
+  evaluationCriteriaId String
+  createdAt            DateTime @default(now())
+
+  checkQuality       CheckQuality       @relation(fields: [checkQualityId], references: [id])
+  evaluationCriteria EvaluationCriteria @relation(fields: [evaluationCriteriaId], references: [id])
+
+  @@unique([checkQualityId, evaluationCriteriaId])
 }
 
 enum SystemConfigOrderType {
@@ -677,6 +690,7 @@ model EvaluationCriteria {
   productId   String
   product     Product  @relation(fields: [productId], references: [id])
   orderEvaluations OrderEvaluationCriteria[]
+  failedCheckQualities CheckQualityFailedEvaluationCriteria[]
 }
 
 model OrderEvaluationCriteria {

--- a/src/orders/dto/done-check-quality.input.ts
+++ b/src/orders/dto/done-check-quality.input.ts
@@ -1,32 +1,47 @@
-import { Field, InputType, Int } from '@nestjs/graphql';
-import { IsString, IsInt, IsOptional, IsArray, Min, IsUUID, ArrayMaxSize, IsNotEmpty } from 'class-validator';
+import { Field, InputType, Int } from "@nestjs/graphql"
+import {
+    IsString,
+    IsInt,
+    IsOptional,
+    IsArray,
+    Min,
+    IsUUID,
+    ArrayMaxSize,
+    IsNotEmpty
+} from "class-validator"
 
 @InputType()
 export class DoneCheckQualityInput {
-  @Field()
-  @IsString()
-  @IsNotEmpty()
-  checkQualityId: string;
+    @Field()
+    @IsString()
+    @IsNotEmpty()
+    checkQualityId: string
 
-  @Field(() => Int)
-  @IsInt()
-  @Min(0)
-  passedQuantity: number;
+    @Field(() => Int)
+    @IsInt()
+    @Min(0)
+    passedQuantity: number
 
-  @Field(() => Int)
-  @IsInt()
-  @Min(0)
-  failedQuantity: number;
+    @Field(() => Int)
+    @IsInt()
+    @Min(0)
+    failedQuantity: number
 
-  @Field({ nullable: true })
-  @IsOptional()
-  @IsString()
-  note?: string;
+    @Field({ nullable: true })
+    @IsOptional()
+    @IsString()
+    note?: string
 
-  @Field(() => [String], { nullable: true })
-  @IsOptional()
-  @IsArray()
-  @IsString({ each: true })
-  @ArrayMaxSize(10)
-  imageUrls?: string[];
-} 
+    @Field(() => [String], { nullable: true })
+    @IsOptional()
+    @IsArray()
+    @IsString({ each: true })
+    @ArrayMaxSize(10)
+    imageUrls?: string[]
+
+    @Field(() => [String], { nullable: true })
+    @IsOptional()
+    @IsArray()
+    @IsString({ each: true })
+    failedEvaluationCriteriaIds?: string[]
+}

--- a/src/orders/entities/check-quality-failed-evaluation-criteria.entity.ts
+++ b/src/orders/entities/check-quality-failed-evaluation-criteria.entity.ts
@@ -1,0 +1,24 @@
+import { Field, ID, ObjectType } from "@nestjs/graphql"
+import { EvaluationCriteriaEntity } from "../../evaluation-criteria/entities/evaluation-criteria.entity"
+
+@ObjectType()
+export class CheckQualityFailedEvaluationCriteriaEntity {
+    @Field(() => ID)
+    id: string
+
+    @Field(() => ID)
+    checkQualityId: string
+
+    @Field(() => ID)
+    evaluationCriteriaId: string
+
+    @Field(() => Date)
+    createdAt: Date
+
+    @Field(() => EvaluationCriteriaEntity)
+    evaluationCriteria: EvaluationCriteriaEntity
+
+    constructor(partial: Partial<CheckQualityFailedEvaluationCriteriaEntity>) {
+        Object.assign(this, partial)
+    }
+}

--- a/src/orders/entities/check-quality.entity.ts
+++ b/src/orders/entities/check-quality.entity.ts
@@ -2,6 +2,7 @@ import { Field, ID, ObjectType, Int, registerEnumType } from "@nestjs/graphql"
 import { QualityCheckStatus } from "@prisma/client"
 import { TaskEntity } from "../../tasks/entities/task.entity"
 import { OrderDetailEntity } from "./order-detail.entity"
+import { CheckQualityFailedEvaluationCriteriaEntity } from "./check-quality-failed-evaluation-criteria.entity"
 
 registerEnumType(QualityCheckStatus, {
     name: "QualityCheckStatus"
@@ -50,6 +51,9 @@ export class CheckQualityEntity {
 
     @Field(() => OrderDetailEntity, { nullable: true })
     orderDetail?: OrderDetailEntity
+
+    @Field(() => [CheckQualityFailedEvaluationCriteriaEntity], { nullable: true })
+    failedEvaluationCriteria?: CheckQualityFailedEvaluationCriteriaEntity[]
 
     constructor(partial: Partial<CheckQualityEntity>) {
         Object.assign(this, partial)

--- a/src/orders/orders.resolver.ts
+++ b/src/orders/orders.resolver.ts
@@ -52,10 +52,8 @@ export class OrdersResolver {
     }
 
     @Query(() => OrderEntity, { name: "order" })
-    async findOne(@Args("id", { type: () => String }) id: string) {
-        const result = await this.ordersService.findOne(id)
-        console.log("result 2", result)
-        return result
+    findOne(@Args("id", { type: () => String }) id: string) {
+        return this.ordersService.findOne(id)
     }
 
     @Mutation(() => OrderEntity)
@@ -95,7 +93,8 @@ export class OrdersResolver {
             input.passedQuantity,
             input.failedQuantity,
             input.note,
-            input.imageUrls
+            input.imageUrls,
+            input.failedEvaluationCriteriaIds
         )
     }
 

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -91,6 +91,7 @@ type CheckQualityEntity {
   checkedAt: DateTime!
   checkedBy: String
   createdAt: DateTime!
+  failedEvaluationCriteria: [CheckQualityFailedEvaluationCriteriaEntity!]
   failedQuantity: Int!
   id: ID!
   imageUrls: [String!]!
@@ -102,6 +103,14 @@ type CheckQualityEntity {
   task: TaskEntity
   taskId: String!
   totalChecked: Int!
+}
+
+type CheckQualityFailedEvaluationCriteriaEntity {
+  checkQualityId: ID!
+  createdAt: DateTime!
+  evaluationCriteria: EvaluationCriteriaEntity!
+  evaluationCriteriaId: ID!
+  id: ID!
 }
 
 """Create Address Input"""
@@ -281,6 +290,7 @@ type District {
 
 input DoneCheckQualityInput {
   checkQualityId: String!
+  failedEvaluationCriteriaIds: [String!]
   failedQuantity: Int!
   imageUrls: [String!]
   note: String


### PR DESCRIPTION
…to order evaluation process

- Introduced the CheckQualityFailedEvaluationCriteria model to track failed evaluation criteria associated with quality checks.
- Updated the GraphQL schema to include failedEvaluationCriteria in CheckQualityEntity and added a new CheckQualityFailedEvaluationCriteriaEntity type.
- Enhanced the OrdersService to handle failed evaluation criteria during quality checks, including validation and storage of criteria IDs.
- Modified DoneCheckQualityInput to accept failedEvaluationCriteriaIds for better integration with the quality check process.
- Created a migration script to establish the new database table and relationships.